### PR TITLE
feat: add link to user profile in posts, issue #30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.60.5",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "lucide-react": "^0.460.0",
         "next": "^15.0.3",
         "prettier": "^3.4.0",
@@ -27,6 +28,7 @@
         "eslint": "^8",
         "eslint-config-next": "15.0.3",
         "postcss": "^8",
+        "prettier-plugin-tailwindcss": "^0.6.9",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
       }
@@ -1850,6 +1852,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -3859,9 +3871,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
@@ -4455,6 +4467,85 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.9.tgz",
+      "integrity": "sha512-r0i3uhaZAXYP0At5xGfJH876W3HHGHDp+LCRUJrs57PBeQ6mYHMwr25KH8NPX44F2yGTvdnH7OqCshlQx183Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig-melody": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig-melody": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint": "^8",
     "eslint-config-next": "15.0.3",
     "postcss": "^8",
+    "prettier-plugin-tailwindcss": "^0.6.9",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }

--- a/src/app/postsFb/components/post.tsx
+++ b/src/app/postsFb/components/post.tsx
@@ -10,21 +10,27 @@ export function Post({
   post: FacebookPost;
 }) {
   return (
-    <div className="border rounded-xl p-3 w-1/3">
-      <div className="flex items-center mb-3">
-        <Image
-          src={author.picture.data.url}
-          alt={author.name}
-          width={author.picture.data.width}
-          height={author.picture.data.height}
-          className="rounded-full"
-        />
+    <div className="w-1/3 rounded-xl border p-3">
+      <div className="mb-3 flex items-center">
+        <a href={author.link} target="_blank" rel="noopener noreferrer">
+          <Image
+            src={author.picture.data.url}
+            alt={author.name}
+            width={author.picture.data.width}
+            height={author.picture.data.height}
+            className="rounded-full"
+          />
+        </a>
         <div className="ml-2 w-full">
-          <p className="font-semibold">{author.name}</p>
+          <p className="font-semibold">
+            <a href={author.link} target="_blank" rel="noopener noreferrer">
+              {author.name}
+            </a>
+          </p>
           <p
-            className="flex items-center text-sm text-gray-500 gap-1"
+            className="flex items-center gap-1 text-sm text-gray-500"
             title={`last updated: ${new Date(
-              post.updated_time
+              post.updated_time,
             ).toLocaleString()}`}
           >
             {new Date(post.created_time).toLocaleString()}
@@ -34,7 +40,7 @@ export function Post({
           </p>
         </div>
       </div>
-      <p className="border-t-2 pt-2 whitespace-pre-line">
+      <p className="whitespace-pre-line border-t-2 pt-2">
         {post.message || <i className="italic text-slate-400">empty post</i>}
       </p>
       {post.full_picture && (

--- a/src/lib/facebook.ts
+++ b/src/lib/facebook.ts
@@ -1,3 +1,15 @@
+/**
+ * Module containing functions related to the Facebook API.
+ *
+ * Access tokens must be generated using the Facebook Graph API Explorer.
+ *
+ * Currently required user token permissions:
+ * - `user_posts` to retrieve the user's posts
+ * - `user_photos` to retrieve the user's profile picture
+ * - `user_link` to retrieve the user's profile link
+ * - `public_profile` (all access tokens require it)
+ */
+
 import { FacebookPost, FacebookUser } from "./types";
 
 const FACEBOOK_API_URL = "https://graph.facebook.com/v21.0";
@@ -14,7 +26,7 @@ const getAccessToken = async () =>
 
 async function fetchFromFacebook<T>(
   path: string,
-  fields: string = ""
+  fields: string = "",
 ): Promise<T | null> {
   const token = await getAccessToken();
   if (!token) {
@@ -46,7 +58,10 @@ async function fetchFromFacebook<T>(
  * If a previous call failed, it will re-attempt to fetch the user data.
  */
 export const getFacebookUser = async () =>
-  (user ??= await fetchFromFacebook<FacebookUser>("me", "id,name,picture"));
+  (user ??= await fetchFromFacebook<FacebookUser>(
+    "me",
+    "id,name,picture,link",
+  ));
 
 /** Retrieves all non-empty Facebook posts made by the user with the current access token, in reverse chronological order (newest first). */
 export async function getFacebookPosts(): Promise<
@@ -54,7 +69,7 @@ export async function getFacebookPosts(): Promise<
 > {
   const data = await fetchFromFacebook<{ data: FacebookPost[] }>(
     "me/posts",
-    "id,message,name,permalink_url,shares,created_time,updated_time,full_picture"
+    "id,message,name,permalink_url,shares,created_time,updated_time,full_picture",
   );
   const posts = data?.data;
   if (!posts) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,7 @@ export interface FacebookPost {
 export interface FacebookUser {
   id: string;
   name: string;
+  link: string;
   picture: {
     data: {
       height: number;


### PR DESCRIPTION
Używanie id użytkownika i wstawianie linka do profilu w formacie `facebook.com/profile.php?id=${user.id}` okazało się jednak niemożliwe, ponieważ facebook nie używa id użytkownika w tym linku, tylko jakiegoś innego id do którego nie mamy dostępu poprzez API. W związku z tym dodałem do requesta o danych użytkownika pole `link` które zwraca to dziwne URL przekierowujące na profil usera, ale jest to chyba jedyne działające rozwiązanie.

Link dodany w elementach zdjęcia profilowego oraz nazwy użytkownika, czyli są dwa anchor tagi.