### PR TITLE
feat: add section on homepage showing news preview, Issue #32

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { Countdown } from "@/components/Countdown";
+import { LatestNews } from "@/components/latest-news/latest-news-section";
 import { Schedule } from "@/components/Schedule";
 
 export default function Home() {
@@ -7,6 +8,7 @@ export default function Home() {
       <div>This is the main page</div>
       <Countdown />
       <Schedule />
+      <LatestNews />
     </>
   );
 }

--- a/src/components/latest-news/latest-news-section.tsx
+++ b/src/components/latest-news/latest-news-section.tsx
@@ -1,0 +1,33 @@
+import { getFacebookPosts } from "@/lib/facebook";
+import { ArrowUpRight } from "lucide-react";
+import Link from "next/link";
+import { Fragment } from "react";
+import { PostPreview } from "./post-preview";
+import { NoDataInfo } from "../ui/NoDataInfo";
+
+export async function LatestNews({}) {
+  const posts = await getFacebookPosts();
+  return (
+    <div className="flex flex-col items-center gap-5 text-sm">
+      <h2 className="text-base font-extrabold">Najnowsze aktualności</h2>
+      <hr className="w-full" />
+      {posts == null ? (
+        <NoDataInfo
+          errorTitle="Brak postów"
+          errorMessage="Nie ma żadnych aktualności do wyświetlenia"
+        />
+      ) : (
+        posts.slice(0, 3).map((post, idx) => (
+          <Fragment key={`post-preview-${idx}`}>
+            <PostPreview post={post} />
+            <hr className="w-full" />
+          </Fragment>
+        ))
+      )}
+      <div className="mb-10 flex justify-center">
+        <Link href="/news">Przejrzyj więcej aktualności</Link>
+        <ArrowUpRight />
+      </div>
+    </div>
+  );
+}

--- a/src/components/latest-news/latest-news-section.tsx
+++ b/src/components/latest-news/latest-news-section.tsx
@@ -4,27 +4,33 @@ import Link from "next/link";
 import { Fragment } from "react";
 import { PostPreview } from "./post-preview";
 import { NoDataInfo } from "../ui/NoDataInfo";
+import { HorizontalRule } from "../ui/horizontal-rule";
+import { HomepageHeader } from "../ui/homepage-header";
 
 export async function LatestNews({}) {
   const posts = await getFacebookPosts();
   return (
-    <div className="flex flex-col items-center gap-5 text-sm">
-      <h2 className="text-base font-extrabold">Najnowsze aktualności</h2>
-      <hr className="w-full" />
-      {posts == null ? (
-        <NoDataInfo
-          errorTitle="Brak postów"
-          errorMessage="Nie ma żadnych aktualności do wyświetlenia"
-        />
-      ) : (
-        posts.slice(0, 3).map((post, idx) => (
-          <Fragment key={`post-preview-${idx}`}>
-            <PostPreview post={post} />
-            <hr className="w-full" />
-          </Fragment>
-        ))
-      )}
-      <div className="mb-10 flex justify-center">
+    <div className="text-xs sm:text-sm md:text-base">
+      <HomepageHeader>Najnowsze aktualności</HomepageHeader>
+      <div className="flex flex-col items-center md:items-start md:gap-5 lg:gap-10">
+        <HorizontalRule />
+        {posts == null ? (
+          <div className="self-center">
+            <NoDataInfo
+              errorTitle="Brak aktualności"
+              errorMessage="Nie udało nam się znaleźć żadnych aktualności. Wróć tutaj później!"
+            />
+          </div>
+        ) : (
+          posts.slice(0, 3).map((post, idx) => (
+            <Fragment key={`post-preview-${idx}`}>
+              <PostPreview post={post} />
+              <HorizontalRule />
+            </Fragment>
+          ))
+        )}
+      </div>
+      <div className="mb-10 mt-5 flex justify-center md:text-lg lg:mt-10 lg:text-2xl">
         <Link href="/news">Przejrzyj więcej aktualności</Link>
         <ArrowUpRight />
       </div>

--- a/src/components/latest-news/post-preview.tsx
+++ b/src/components/latest-news/post-preview.tsx
@@ -7,20 +7,26 @@ import { useState } from "react";
 import { Button } from "../ui/button";
 
 export function PostPreview({ post }: { post: FacebookPost }) {
-  const date = format(post.created_time, "dd MMMM yyyy", { locale: pl });
-  const postTitle = post.title || post.message?.split("\n")[0];
+  const date = format(post.updated_time, "dd MMMM yyyy", { locale: pl });
+  let postTitle = post.title;
+  let postMessage = post.message;
+  if (postTitle == null) {
+    const splittedMessage = post.message?.split("\n") ?? [];
+    postTitle = splittedMessage.shift();
+    postMessage = splittedMessage.join("\n");
+  }
   const [showDetails, setShowDetails] = useState(false);
   return (
-    <>
-      <div className="flex w-full flex-col items-start gap-2 px-7 py-3">
-        <p className="text-xs text-primary">{date}</p>
-        {postTitle ? (
-          <h3 className="font-bold">{postTitle}</h3>
-        ) : (
-          <h3>
+    <div className="flex w-full flex-col items-start gap-2 px-3 py-3 sm:px-7 md:flex-row md:justify-between md:px-12 lg:justify-around lg:px-24">
+      <p className="text-xs text-primary md:text-sm lg:text-base">{date}</p>
+      <div className="md:w-3/4 lg:w-2/3">
+        <h3 className="md:text-xl lg:text-2xl">
+          {postTitle ? (
+            <b className="font-bold">{postTitle}</b>
+          ) : (
             <i>Brak tytułu</i>
-          </h3>
-        )}
+          )}
+        </h3>
         <div className={`flex flex-col items-start gap-3`}>
           {
             <div
@@ -31,7 +37,7 @@ export function PostPreview({ post }: { post: FacebookPost }) {
               }`}
             >
               <p className="overflow-hidden whitespace-pre-line">
-                {post.message}
+                {postMessage}
               </p>
             </div>
           }
@@ -44,7 +50,6 @@ export function PostPreview({ post }: { post: FacebookPost }) {
           </Button>
         </div>
       </div>
-      <hr />
-    </>
+    </div>
   );
 }

--- a/src/components/latest-news/post-preview.tsx
+++ b/src/components/latest-news/post-preview.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { FacebookPost } from "@/lib/types";
+import { format } from "date-fns";
+import { pl } from "date-fns/locale";
+import { useState } from "react";
+import { Button } from "../ui/button";
+
+export function PostPreview({ post }: { post: FacebookPost }) {
+  const date = format(post.created_time, "dd MMMM yyyy", { locale: pl });
+  const postTitle = post.title || post.message?.split("\n")[0];
+  const [showDetails, setShowDetails] = useState(false);
+  return (
+    <>
+      <div className="flex w-full flex-col items-start gap-2 px-7 py-3">
+        <p className="text-xs text-primary">{date}</p>
+        {postTitle ? (
+          <h3 className="font-bold">{postTitle}</h3>
+        ) : (
+          <h3>
+            <i>Brak tytułu</i>
+          </h3>
+        )}
+        <div className={`flex flex-col items-start gap-3`}>
+          {
+            <div
+              className={`grid transition-all ease-in-out ${
+                showDetails
+                  ? "grid-rows-animate-height-open visible opacity-100"
+                  : "grid-rows-animate-height-closed invisible opacity-0"
+              }`}
+            >
+              <p className="overflow-hidden whitespace-pre-line">
+                {post.message}
+              </p>
+            </div>
+          }
+          <Button
+            className="cursor-pointer list-none underline"
+            variant="ghost"
+            onClick={() => setShowDetails((old) => !old)}
+          >
+            {showDetails ? "Zwiń" : "Zobacz więcej"}
+          </Button>
+        </div>
+      </div>
+      <hr />
+    </>
+  );
+}

--- a/src/components/ui/homepage-header.tsx
+++ b/src/components/ui/homepage-header.tsx
@@ -1,0 +1,7 @@
+export function HomepageHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="mb-2 w-fit rounded-r-full bg-gradient-main px-5 py-2 text-base font-extrabold text-background sm:px-7 sm:text-xl md:mb-4 md:px-9 md:text-2xl lg:mb-5 lg:px-10 lg:py-3 lg:text-4xl xl:mb-7 xl:px-12 xl:py-5 xl:text-5xl">
+      {children}
+    </h2>
+  );
+}

--- a/src/components/ui/horizontal-rule.tsx
+++ b/src/components/ui/horizontal-rule.tsx
@@ -1,0 +1,3 @@
+export function HorizontalRule() {
+  return <hr className="w-full border-b-2 border-gray-300" />;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -60,12 +60,18 @@ export default {
         sm: "calc(var(--radius) - 4px)",
       },
       backgroundImage: {
-        'gradient-main': 'radial-gradient(circle at top left, hsl(var(--primary)), hsl(var(--secondary)))',
-        'gradient-secondary': 'radial-gradient(circle at bottom right, hsl(var(--primary)), hsl(var(--secondary)))',
+        "gradient-main":
+          "radial-gradient(circle at top left, hsl(var(--primary)), hsl(var(--secondary)))",
+        "gradient-secondary":
+          "radial-gradient(circle at bottom right, hsl(var(--primary)), hsl(var(--secondary)))",
       },
       spacing: {
-        '90': '22rem'
-      }
+        "90": "22rem",
+      },
+      gridTemplateRows: {
+        "animate-height-open": "1fr",
+        "animate-height-closed": "0fr",
+      },
     },
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
Zmiany:
- dodano najnowsze 3 posty na główną
- link do wszystkich postów `/news`
- rozwijanie i zwijanie treści postów
- mobile layout
- responsywność dla md, lg, xl
- reusable component dla headerów na homepage'u