### PR TITLE
fix exceeding the Facebook API rate limit with regular use

### DIFF
--- a/src/lib/facebook.ts
+++ b/src/lib/facebook.ts
@@ -70,7 +70,7 @@ async function fetchFromFacebook<T>(
     if (fields) {
       url.searchParams.append("fields", fields);
     }
-    const headers: RequestInit["headers"] = {};
+    const headers: HeadersInit = {};
     if (useAuthentication) {
       getAccessTokenPromise = getAccessToken();
       const token = await getAccessTokenPromise;
@@ -81,7 +81,10 @@ async function fetchFromFacebook<T>(
 
       headers.Authorization = `Bearer ${token}`;
     }
-    const response = await fetch(url.toString(), { headers });
+    const response = await fetch(url.toString(), {
+      headers,
+      next: { revalidate: 300 },
+    });
     const data = (await response.json()) as T;
     if (!response.ok) {
       console.error(


### PR DESCRIPTION
dodano 5-minutowe cachowanie dla wszystkich requestów do API Facebook-a