### PR TITLE
fix: limit faqs on the main page

### DIFF
--- a/src/components/faq/faq-section.tsx
+++ b/src/components/faq/faq-section.tsx
@@ -1,6 +1,9 @@
+import Link from "next/link";
+
 import { fetchData } from "@/lib/api";
 import type { Faq } from "@/lib/types";
 
+import { Button } from "../button";
 import { PaddingWrapper } from "../padding-wrapper";
 import { FrequentlyAskedQuestion } from "./faq-card";
 
@@ -10,7 +13,7 @@ export async function FrequentlyAskedQuestions() {
     return null;
   }
 
-  const slicedFaqs = faqs.data.slice(0, 5);
+  const slicedFaqs = faqs.data.slice(0, 6);
 
   return (
     <PaddingWrapper>
@@ -28,6 +31,14 @@ export async function FrequentlyAskedQuestions() {
           />
         ))}
       </div>
+      <Button
+        as={Link}
+        href="/faq"
+        variant="secondary"
+        className="ml-4 mr-20 w-full max-w-[225px]"
+      >
+        zobacz więcej
+      </Button>
     </PaddingWrapper>
   );
 }

--- a/src/components/faq/faq-section.tsx
+++ b/src/components/faq/faq-section.tsx
@@ -9,6 +9,9 @@ export async function FrequentlyAskedQuestions() {
   if (faqs.data.length === 0) {
     return null;
   }
+
+  const slicedFaqs = faqs.data.slice(0, 5);
+
   return (
     <PaddingWrapper>
       <div className="mb-14 mt-24 box-border grid grid-cols-12 justify-between gap-2 sm:gap-4 md:gap-6">
@@ -17,7 +20,7 @@ export async function FrequentlyAskedQuestions() {
             Częste Pytania
           </h2>
         </div>
-        {faqs.data.map((faq, index) => (
+        {slicedFaqs.map((faq, index) => (
           <FrequentlyAskedQuestion
             key={faq.id}
             faqs={faqs.data}


### PR DESCRIPTION
bajo jajo bajo jajo
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Limits FAQs on the main page to six and adds a button to view more in `faq-section.tsx`.
> 
>   - **Behavior**:
>     - Limits FAQs displayed on the main page to 6 in `FrequentlyAskedQuestions()` in `faq-section.tsx`.
>     - Adds "zobacz więcej" button linking to `/faq` in `faq-section.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-juwenalia&utm_source=github&utm_medium=referral)<sup> for 2a3bf9e8dd5ff2a11001a1edfdaa685660cf7f4f. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->