### PR TITLE
fix(artists): prevent card flip when dragging

### DIFF
--- a/src/components/artists/artist.tsx
+++ b/src/components/artists/artist.tsx
@@ -9,16 +9,12 @@ import type { ArtistProps } from "@/lib/types";
 
 const CLICK_THRESHOLD = 5;
 
-function isPureClick(
-  start: {
-    x: number;
-    y: number;
-  },
-  end: {
-    x: number;
-    y: number;
-  },
-) {
+interface Point {
+  x: number;
+  y: number;
+}
+
+function isPureClick(start: Point, end: Point) {
   return Math.hypot(end.x - start.x, end.y - start.y) < CLICK_THRESHOLD;
 }
 
@@ -32,7 +28,7 @@ export function Artist({
   description,
 }: ArtistProps) {
   // pointer position for click detection
-  const pointerStart = useRef({ x: 0, y: 0 });
+  const pointerStart = useRef<Point>({ x: 0, y: 0 });
   const [flip, setFlip] = useState(false);
   const weekDays = ["NIE", "PON", "WT", "ŚR", "CZW", "PT", "SOB"];
 


### PR DESCRIPTION
### Co?

Karta artysty obraca się teraz tylko po kliknięciu na nią. Dotychczas obracała się również podczas przeciągania w galerii artystów.

### Dlaczego?

Użytkownik przeciągając kartę w galerii również powodował jej obrócenie, co było mylące i psuło przewijanie galerii.

### Jak?

Przy naciśnięciu klawisza myszy na kracie artysty jest teraz zapisywana pozycja kursora, a następnie przy odpuszczeniu klawisza zostaje sprawdzona odległość jaką przebył kursor. Jeśli jest ona mniejsza niż 5 pikseli, zostaje to uznane za kliknięcie i karta artysty zostaje obrócona.

Naprawia #144 