### PR TITLE
feat(navbar-mobile): add link to event's terms and conditions

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -9,7 +9,11 @@ import Solvro from "@/../public/logo-solvro.svg";
 import Logo from "@/../public/logo.svg";
 import { HorizontalRule } from "@/components/horizontal-rule";
 import { PaddingWrapper } from "@/components/padding-wrapper";
-import { FOOTER_LINKS, NAV_LINKS } from "@/config/data";
+import {
+  FOOTER_LINKS,
+  NAV_LINKS,
+  TERMS_AND_CONDITIONS_URL,
+} from "@/config/data";
 import { cn } from "@/lib/utils";
 
 import { OpenBugReportFormButton } from "./bug-report-form/open-form-button";
@@ -116,10 +120,7 @@ function Footer() {
             text="Inne"
             className="col-span-2 flex w-full flex-grow pt-6 sm:col-span-3 md:col-span-4 lg:col-span-1 lg:row-start-2 3/2xl:row-start-1"
           >
-            <ListItem
-              text="Regulamin"
-              url="/Regulamin_Juwenalia2026_WroclawRazem2026.pdf"
-            />
+            <ListItem text="Regulamin" url={TERMS_AND_CONDITIONS_URL} />
             <ListItem
               text="Polityka prywatności"
               url={FOOTER_LINKS.privacyPolicy}

--- a/src/components/navbar-mobile.tsx
+++ b/src/components/navbar-mobile.tsx
@@ -11,7 +11,11 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
-import { NAV_LINKS, TICKETMASTER_URL } from "@/config/data";
+import {
+  NAV_LINKS,
+  TERMS_AND_CONDITIONS_URL,
+  TICKETMASTER_URL,
+} from "@/config/data";
 
 interface NavbarMobileProps {
   onOpenChange: (open: boolean) => void;
@@ -85,10 +89,11 @@ export function NavbarMobile({ isOpened, onOpenChange }: NavbarMobileProps) {
               </Link>
             ))}
             <Link
-              href={"/Regulamin_Juwenalia2026_WroclawRazem2026.pdf"}
+              href={TERMS_AND_CONDITIONS_URL}
               aria-label="Regulamin"
               className="nav-link link-item"
               target="_blank"
+              rel="noopener noreferrer"
             >
               Regulamin
             </Link>

--- a/src/components/navbar-mobile.tsx
+++ b/src/components/navbar-mobile.tsx
@@ -84,6 +84,14 @@ export function NavbarMobile({ isOpened, onOpenChange }: NavbarMobileProps) {
                 {name}
               </Link>
             ))}
+            <Link
+              href={"/Regulamin_Juwenalia2026_WroclawRazem2026.pdf"}
+              aria-label="Regulamin"
+              className="nav-link link-item"
+              target="_blank"
+            >
+              Regulamin
+            </Link>
           </div>
 
           <Button

--- a/src/config/data.ts
+++ b/src/config/data.ts
@@ -58,3 +58,6 @@ export const ORGANISATION_ROLES = {
 
 export const TICKETMASTER_URL =
   "https://www.ticketmaster.pl/artist/juwenalia-wroclawrazem-bilety/1277573";
+
+export const TERMS_AND_CONDITIONS_URL =
+  "/Regulamin_Juwenalia2026_WroclawRazem2026.pdf";


### PR DESCRIPTION
Add link to terms and conditions to mobile navbar

<img width="427" height="857" alt="image" src="https://github.com/user-attachments/assets/c9106106-36de-4c5c-96c4-4101a63d6ef7" />
